### PR TITLE
Fix broken RSS link in footer

### DIFF
--- a/layouts/partials/footer.html.twig
+++ b/layouts/partials/footer.html.twig
@@ -31,7 +31,7 @@
 					{% endif %}
 
 					<li class="nav-item">
-						<a class="nav-link" href="{{ url('news/rss.xml') }}" title="Subscribe to our news" target="_blank" rel="noopener"><i class="fas fa-rss"></i></a>
+						<a class="nav-link" href="{{ url('news/atom.xml') }}" title="Subscribe to our news" target="_blank" rel="noopener"><i class="fas fa-rss"></i></a>
 					</li>
 				</ul>
 			</div>


### PR DESCRIPTION
Link was pointing to `news/rss.xml` while it should be `news/atom.xml`.

Closes #6